### PR TITLE
fix: return gracefully if search-term does not yield any results 

### DIFF
--- a/src/api/__tests__/query-episodes-response.type.test.ts
+++ b/src/api/__tests__/query-episodes-response.type.test.ts
@@ -14,7 +14,7 @@ describe('query-episode-response type', () => {
     expect(result).toEqual(right(sampleQueryEpisodesResponse.data))
   })
 
-  it('rejects an invalid location', () => {
+  it('rejects an invalid response', () => {
     const location = {}
 
     const parsed = QueryEpisodesResponse.decode(location.toString())

--- a/src/api/__tests__/query-episodes.test.ts
+++ b/src/api/__tests__/query-episodes.test.ts
@@ -20,6 +20,24 @@ describe('query-episodes', () => {
     expect(result).toEqual(sampleQueryEpisodesResponse.data)
   })
 
+  it('returns an error if search-term does not yield any results', async () => {
+    gqlClientMock.query.mockReturnValueOnce({
+      data: {
+        episodes: {
+          info: {
+            count: null,
+          },
+          results: [
+          ],
+        },
+      },
+    })
+
+    const result = await queryEpisodeDetails('potqweqweqweeqwweqweewqqweion')
+
+    expect(result).toBeInstanceOf(Error)
+  })
+
   it('returns an error if sending query fails', async () => {
     gqlClientMock.query.mockImplementationOnce(() => new Error())
 

--- a/src/api/query-episodes-response.type.ts
+++ b/src/api/query-episodes-response.type.ts
@@ -1,7 +1,10 @@
 import * as t from 'io-ts'
 
 const QueryEpisodesResponseInfo = t.exact(t.type({
-  count: t.number,
+  count: t.union([
+    t.number,
+    t.null,
+  ]),
 }))
 export type QueryEpisodesResponseInfo = t.TypeOf<typeof QueryEpisodesResponseInfo>
 

--- a/src/api/query-episodes.ts
+++ b/src/api/query-episodes.ts
@@ -7,7 +7,11 @@ export const queryEpisodeDetails = async (searchTerm: string): Promise<QueryEpis
   try {
     const query = { query: createQuery(searchTerm) }
     const result = await gqlClient.query(query)
-    return valueOrThrow(QueryEpisodesResponse, result.data)
+    const validatedResult = valueOrThrow(QueryEpisodesResponse, result.data)
+    if(validatedResult.episodes.info.count === null) {
+      return new Error(`Search-term: "${searchTerm}" did not yield any results.`)
+    }
+    return validatedResult
   } catch (e) {
     const error = e as Error
     return new Error(`Failed to query episode details: ${error.message}`)


### PR DESCRIPTION
### Scope
This PR deals with the case that a given search-term does not yield any results.

### For the reviewer
You can basically use any bogus search-term (like `qweqweqweqwwqqweeq`).